### PR TITLE
feature: Generalize Route Matching

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
   "singleQuote": true,
-  "printWidth": 80,
+  "printWidth": 120,
   "trailingComma": "all"
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ By default, the tool will crawl through your project's filesystem and search for
 
 This information can then be fed into Express directly.
 
-## For Example,
+## Custom matchers
+In addition to the built-in route matchers that come bundled by default with the tool, you can add custom matchers to handle more complex cases. If you feel the matcher you create is useful, please open a PR to petition for its inclusion as a default!
+
+## An Example
 If you have a folder structure like the following:
 ```
 {
@@ -68,5 +71,5 @@ The tool will generate the following route information:
 ]
 ```
 
-## Love it? Hate it? I want to know! (Maybe not the "hate it" part)
+## Love it? Hate it? I want to know!
 This project was inspired by code in a work project and extended to work with a side project of mine so I fully expect that I made assumptions other people would not - I'll attempt to add some of the first issues myself to track what are likely going to be points of pain for new users, but if the tool isn't working as you'd expect feel free to open up an issue on the project's [Issues page](https://github.com/mdhornet90/fs-to-http-builder/issues). 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-to-http-builder",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "A utility that can generate express route information from your project's filesystem",
   "main": "index.js",
   "repository": "https://github.com/mdhornet90/fs-to-http-builder.git",

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ export default (
     httpMethods = ['post', 'get', 'put', 'patch', 'delete'],
     fileExclusionPatterns = ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
     fileInclusionPattern = '**/endpoints/**/*[jt]s?(x)',
+    customRouteMatchers = [],
   } = {},
 ) => {
   const endpointPaths = getAllFilesFromRoot(rootPath).filter(aPath => {
@@ -59,7 +60,12 @@ export default (
   return Object.keys(endpointFileGroups).reduce(
     (acc, folder) => [
       ...acc,
-      ...extractValidRoutes(folder, endpointFileGroups[folder], DEFAULT_VALID_ROUTE_MATCHERS, { httpMethods }),
+      ...extractValidRoutes(
+        folder,
+        endpointFileGroups[folder],
+        [...customRouteMatchers, ...DEFAULT_VALID_ROUTE_MATCHERS],
+        { httpMethods },
+      ),
     ],
     [],
   );

--- a/src/index.js
+++ b/src/index.js
@@ -6,21 +6,52 @@ import mm from 'micromatch';
 
 const debug = Debug('fs-to-http-builder');
 
+const DEFAULT_VALID_ROUTE_MATCHERS = [
+  {
+    testFn: ({ routeMetadata: { name }, httpMethods }) => httpMethods.includes(name),
+    extractionFn: ({ routeMetadata: { name, route }, loadedModule, debugLogger }) => {
+      debugLogger(`Adding route with the name of http method ${name}: ${route}`);
+      return {
+        method: name,
+        route: `/${route}`,
+        handler: loadedModule.default,
+      };
+    },
+  },
+  {
+    testFn: ({ loadedModule, httpMethods }) => Object.keys(loadedModule).some(e => httpMethods.includes(e)),
+    extractionFn: ({ loadedModule, routeMetadata: { name, route }, httpMethods, debugLogger }) =>
+      Object.keys(loadedModule)
+        .filter(exportName => {
+          const result = httpMethods.includes(exportName);
+          if (!result) {
+            debugLogger(`  Skipping non-HTTP-method export ${exportName}`);
+          }
+          return result;
+        })
+        .map(exportName => {
+          const finalizedRoute = buildEndpointRoute(route, name);
+          debugLogger(`  Adding route with the name of http method ${name}`);
+          return {
+            method: exportName,
+            route: finalizedRoute,
+            handler: loadedModule[exportName],
+          };
+        }),
+  },
+];
+
 export default (
   rootPath,
   {
     httpMethods = ['post', 'get', 'put', 'patch', 'delete'],
-    fileExclusionPatterns = [
-      '**/__tests__/**/*.[jt]s?(x)',
-      '**/?(*.)+(spec|test).[jt]s?(x)',
-    ],
+    fileExclusionPatterns = ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
     fileInclusionPattern = '**/endpoints/**/*[jt]s?(x)',
   } = {},
 ) => {
   const endpointPaths = getAllFilesFromRoot(rootPath).filter(aPath => {
     const result =
-      !mm.any(aPath, fileExclusionPatterns, { dot: true }) &&
-      mm.isMatch(aPath, fileInclusionPattern, { dot: true });
+      !mm.any(aPath, fileExclusionPatterns, { dot: true }) && mm.isMatch(aPath, fileInclusionPattern, { dot: true });
     debug(`Is path ${aPath} a match for an endpoint? ${result ? 'Yes' : 'No'}`);
     return result;
   });
@@ -28,9 +59,7 @@ export default (
   return Object.keys(endpointFileGroups).reduce(
     (acc, folder) => [
       ...acc,
-      ...extractValidRoutes(folder, endpointFileGroups[folder], {
-        httpMethods,
-      }),
+      ...extractValidRoutes(folder, endpointFileGroups[folder], DEFAULT_VALID_ROUTE_MATCHERS, { httpMethods }),
     ],
     [],
   );
@@ -43,9 +72,7 @@ function getAllFilesFromRoot(root) {
     const current = remainingFiles.pop();
     const status = fs.statSync(current);
     if (status.isDirectory()) {
-      const subFiles = fs
-        .readdirSync(current)
-        .map(file => path.join(current, file));
+      const subFiles = fs.readdirSync(current).map(file => path.join(current, file));
       remainingFiles = [...subFiles, ...remainingFiles];
     } else {
       debug(`Found file: ${current}`);
@@ -73,40 +100,22 @@ function groupFilesByEndpointDirectories(paths) {
   return groups;
 }
 
-function extractValidRoutes(root, pathsToPotentialRoutes, { httpMethods }) {
+function extractValidRoutes(root, pathsToPotentialRoutes, routerMatcherSuite, { httpMethods }) {
   return pathsToPotentialRoutes.reduce((acc, pathToRoute) => {
     // eslint-disable-next-line global-require, import/no-dynamic-require
     const loadedModule = require(pathToRoute);
-    const { name, route } = extractRoute(root, pathToRoute);
-    const moduleExports = Object.keys(loadedModule);
-    if (httpMethods.includes(name)) {
-      debug(`Adding route with the name of http method ${name}: ${route}`);
-      acc.push({
-        method: name,
-        route: `/${route}`,
-        handler: loadedModule.default,
+    const routeMetadata = extractRoute(root, pathToRoute);
+    const match = routerMatcherSuite.find(({ testFn }) =>
+      testFn({ loadedModule, routeMetadata, httpMethods, debugLogger: debug }),
+    );
+    if (match) {
+      const extractedRouteHandler = match.extractionFn({
+        loadedModule,
+        routeMetadata,
+        httpMethods,
+        debugLogger: debug,
       });
-    } else if (moduleExports.some(e => httpMethods.includes(e))) {
-      debug(`Extracting http methods from file ${name}`);
-      acc.push(
-        ...moduleExports
-          .filter(exportName => {
-            const result = httpMethods.includes(exportName);
-            if (!result) {
-              debug(`  Skipping non-HTTP-method export ${exportName}`);
-            }
-            return result;
-          })
-          .map(exportName => {
-            const finalizedRoute = buildEndpointRoute(route, name);
-            debug(`  Adding route with the name of http method ${name}`);
-            return {
-              method: exportName,
-              route: finalizedRoute,
-              handler: loadedModule[exportName],
-            };
-          }),
-      );
+      acc.push(...(Array.isArray(extractedRouteHandler) ? extractedRouteHandler : [extractedRouteHandler]));
     }
     return acc;
   }, []);
@@ -127,11 +136,7 @@ function buildEndpointRoute(route, name) {
   if (name !== 'index') {
     routeElements.push(name);
   } else {
-    debug(
-      `Found index file, using name of enclosing folder (${
-        routeElements[routeElements.length - 1]
-      })`,
-    );
+    debug(`Found index file, using name of enclosing folder (${routeElements[routeElements.length - 1]})`);
   }
   return `/${routeElements.join('/')}`;
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -10,10 +10,7 @@ expect.extend({
   toMatchFunction(receivedFn, expectedFnContents) {
     const pass = receivedFn.toString() === expectedFnContents;
     return {
-      message: () =>
-        `expected ${receivedFn.toString()} ${
-          pass ? 'not ' : ''
-        }to match ${expectedFnContents}`,
+      message: () => `expected ${receivedFn.toString()} ${pass ? 'not ' : ''}to match ${expectedFnContents}`,
       pass,
     };
   },
@@ -39,9 +36,7 @@ describe('Route Builder Tests', () => {
     });
 
     test('The builder will not generate routes from directories that do not contain an "endpoints" folder', async () => {
-      await fsify(
-        translateDirectoryStructure({ 'someFolder/thisFile': 'isUseless' }),
-      );
+      await fsify(translateDirectoryStructure({ 'someFolder/thisFile': 'isUseless' }));
       expect(fsToHttpBuilder(TESTING_DIRECTORY)).toEqual([]);
     });
 
@@ -104,11 +99,9 @@ describe('Route Builder Tests', () => {
       await fsify(
         translateDirectoryStructure({
           'someFolder/api/endpoints/foo/bar': {
-            'baz.js':
-              'module.exports = { get: () => {}, post: () => {}, blah: () => {} }',
+            'baz.js': 'module.exports = { get: () => {}, post: () => {}, blah: () => {} }',
             'thiswontmatch.js': 'module.exports = { default: () => {} }',
-            'anothernonmatch.js':
-              'module.exports = { blah: () => {}, foo: () => {} }',
+            'anothernonmatch.js': 'module.exports = { blah: () => {}, foo: () => {} }',
           },
         }),
       );
@@ -182,9 +175,7 @@ function translateDirectoryStructure(directory) {
     if (hasOneComponent && typeof contents === 'string') {
       return { type: Fsify.FILE, name: key, contents };
     }
-    const nextDirectory = hasOneComponent
-      ? contents
-      : { [rest.join('/')]: contents };
+    const nextDirectory = hasOneComponent ? contents : { [rest.join('/')]: contents };
     return {
       type: Fsify.DIRECTORY,
       name: first,

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -164,6 +164,39 @@ describe('Route Builder Tests', () => {
         handler: expect.any(Function),
       });
     });
+
+    test('The builder accepts custom route matchers to extend functionality', async () => {
+      await fsify(
+        translateDirectoryStructure({
+          'someFolder/api/endpoints/users/_id': {
+            'whatever.js': 'module.exports = { default: () => {} }',
+          },
+        }),
+      );
+
+      const handler = () => true;
+      const routes = fsToHttpBuilder(TESTING_DIRECTORY, {
+        customRouteMatchers: [
+          {
+            testFn() {
+              return true;
+            },
+            extractionFn() {
+              return {
+                method: 'imadeitup',
+                route: 'foo',
+                handler,
+              };
+            },
+          },
+        ],
+      });
+      expect(routes).toContainEqual({
+        method: 'imadeitup',
+        route: 'foo',
+        handler,
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Generalizing logic that attempts to match what's considered a "route handler" to allow for custom, user-created entries.